### PR TITLE
Update test.ex to fix documentation typo

### DIFF
--- a/lib/mix/lib/mix/tasks/test.ex
+++ b/lib/mix/lib/mix/tasks/test.ex
@@ -86,7 +86,7 @@ defmodule Mix.Tasks.Test do
       test/foo_test.exs:5
 
   If you want to re-run only this test, all you need to do is to
-  copy the line above and past it in front of `mix test`:
+  copy the line above and paste it in front of `mix test`:
 
       mix test test/foo_test.exs:5
 


### PR DESCRIPTION
Fixes typo in the mix test documentation to change "past" to "paste".